### PR TITLE
Bump Cheerio version so it works.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "coffee-script" : "1.6.3",
     "connect-assets": "2.4.3",
     "request": "2.21.0",
-    "cheerio": "0.12.0"
+    "cheerio": "0.12.3"
   },
   "engines": {
 	"node": ">=0.8.16",


### PR DESCRIPTION
Bump the Cheerio version so it works with newer node versions.  This make the project run on my Mac and more conveniently on AWS.  It's live here:

http://igem.aybabt.me/
